### PR TITLE
Attempting to fix the Travis CI Build bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,15 @@ node_js: 8
 
 cache: yarn
 
-before_script:
-  - yarn global add firebase-tools
-
 branches:
   only:
   - master
 
-script:
+before_deploy:
   - yarn build
-  - firebase deploy --token $FIREBASE_TOKEN
+
+deploy:
+  provider: firebase
+  token:
+    secure: $FIREBASE_TOKEN
+  project: "ask-a-dev-marketing"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -rf dist && mkdir dist && NODE_ENV=production webpack -p --config ./webpack.prod.config.js && cp -R static dist && yarn bolt",
+    "test": "echo \"no tests defined\"",
     "deploy": "yarn build && firebase deploy && rm -rf dist",
     "start": "webpack-dev-server --progress --colors --hot --content-base . --config ./webpack.config.js",
     "bolt": "yarn bolt:compile && yarn bolt:build",


### PR DESCRIPTION
Travis was attempting to build on all branches, I've redefined some of the build process.

I don't have access to Firebase but this needs to be run locally to get the token;

```
# This generates a token, e.g. "1/AD7sdasdasdKJA824OvEFc1c89Xz2ilBlaBlaBla"
firebase login:ci
# Encrypt this token
travis encrypt "1/AD7sdasdasdKJA824OvEFc1c89Xz2ilBlaBlaBla" --add
# This command may generate a warning ("If you tried to pass the name of the repository as the first argument, you probably won't get the results you wanted"). You can ignore it.
```