### PR TITLE
fix alt text for mentors

### DIFF
--- a/scripts/components/Mentors/Presenter.js
+++ b/scripts/components/Mentors/Presenter.js
@@ -20,7 +20,7 @@ const Mentor = ({
   <div className="dev-box">
     <header>
       <a href={`https://github.com/${githubUsername}`}>
-        <img src={photoURL} alt={name} />
+        <img src={photoURL} alt={displayName} />
       </a>
       <a href={url}>
         <h4>{displayName}</h4>


### PR DESCRIPTION
This resolves what appears to be a typo for Mentor image alt text.

This also would improve the experience for people using screen readers.